### PR TITLE
Make OOM not be a SIGKILL

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Thanks [@hiperioncn](https://github.com/hiperioncn) and [@cezar-carneiro](https:
 
 ### Add dependency
 ```groovy
-compile 'io.paperdb:paperdb:2.6'
+implementation 'io.paperdb:paperdb:2.6'
 ```
 
 RxJava wrapper for Paper is available as a separate lib [RxPaper2](https://github.com/pakoito/RxPaper2). Thanks [@pakoito](https://github.com/pakoito) for it!


### PR DESCRIPTION
compile is now (at least, as of April 2018) obsolete. See https://github.com/pilgr/Paper/issues/127#issuecomment-450790889